### PR TITLE
[ PPWP-877 ] - Add CHO Pro E2E Test

### DIFF
--- a/cypress/integration/checkout-pix.feature
+++ b/cypress/integration/checkout-pix.feature
@@ -6,7 +6,7 @@ Feature: Disponibilizar ao buyer mlb o pagamento de sua compra através do Check
         And que eu esteja na página de checkout
         And que preenchi corretamente os detalhes de faturamento
         And que cliquei na opção de pagamento com o checkout Pix
-        And cliquei em finalizar a compra
+        When cliquei em finalizar a compra
         Then devo ser direcionado para a tela de pedido recebido
         And devo visualizar uma seção com o QR Code e o código do Pix
-        And na página do pedido eu devo visualizar o status de pagamento pendente
+        And na página do pedido eu devo visualizar o status de pagamento pendente do pix

--- a/cypress/integration/checkout-pro.feature
+++ b/cypress/integration/checkout-pro.feature
@@ -1,13 +1,42 @@
 Feature: Disponibilizar ao buyer o pagamento de sua compra através do Checkout Pro
 
     # Preconditions: mlb credentials
-    Scenario: Realizando um pagamento com sucesso
+    Scenario: Realizando um pagamento com sucesso usando um meio off
         Given que eu tenha um produto no carrinho
         And que eu esteja na página de checkout
         And preenchi corretamente os detalhes de faturamento
         And que cliquei na opção de pagamento com o checkout PRO
-        And cliquei em finalizar a compra
+        When cliquei em finalizar a compra
         Then devo ser redirecionado para o Mercado Pago
-        And deve concluir o fluxo de pagamento
+        And deve concluir o fluxo de pagamento com Pix
         And ao concluir o fluxo de pagamento, deve ser redirecionado de volta a loja, na tela de pedido recebido
-        And na página do pedido eu devo visualizar o status de pagamento aprovado
+        And na página do pedido eu devo visualizar o status de pagamento pendente
+
+    Scenario: Realizando um pagamento com sucesso usando cartão
+        Given que eu tenha um produto no carrinho
+        And que eu esteja na página de checkout
+        And preenchi corretamente os detalhes de faturamento
+        And que cliquei na opção de pagamento com o checkout PRO
+        When cliquei em finalizar a compra
+        Then devo ser redirecionado para o Mercado Pago
+        And deve concluir o fluxo de pagamento com cartão
+        And ao concluir o fluxo de pagamento, devo ver a tela de congrats
+
+    Scenario: Realizando um pagamento sem sucesso usando cartão
+        Given que eu tenha um produto no carrinho
+        And que eu esteja na página de checkout
+        And preenchi corretamente os detalhes de faturamento
+        And que cliquei na opção de pagamento com o checkout PRO
+        When cliquei em finalizar a compra
+        Then devo ser redirecionado para o Mercado Pago
+        And deve falhar o fluxo de pagamento com cartão
+        And ao concluir o fluxo de pagamento, devo ver a tela de erro
+
+    Scenario: Realizando um pagamento com sucesso usando saldo em conta
+        Given que eu tenha um produto no carrinho
+        And que eu esteja na página de checkout
+        And preenchi corretamente os detalhes de faturamento
+        And que cliquei na opção de pagamento com o checkout PRO
+        When cliquei em finalizar a compra
+        Then devo ser redirecionado para o Mercado Pago
+        And deve concluir o fluxo de pagamento com saldo em conta

--- a/woocommerce/support/elements/mp/checkout-elements.js
+++ b/woocommerce/support/elements/mp/checkout-elements.js
@@ -2,7 +2,26 @@ export const MpCheckoutElements = {
     paymentMethods: {
         pix: {
             option: '#group_form_scroller > ul.options-list.ui-card.select_general_payment_options > li.options-list__item.item-pix',
+        },
+        creditCard: {
+            option: '#group_form_scroller > ul.options-list.ui-card.select_general_payment_options > li.options-list__item.item-new_card_row',
+        },
+        accountMoney: {
+            option: '#group_form_scroller > ul.options-list.ui-card.select_mp_login > li'
         }
     },
     finishButton: '#pay',
+    nextButton : '#submit',
+    continueButton: '#continue_button',
+    cardForm: {
+        cardNumber:'#card_number',
+        expirationDate:'#input_expiration_date',
+        holderName:'#fullname',
+        cvv: '#cvv',
+        document: '#number',
+        installment: '#select_installments > ul > li.options-list__item.item-1'
+    }, 
+    emailInput: '#user_id',
+    passwordInput: '#password',
+    loginButton: '#action-complete'
 }

--- a/woocommerce/support/pageObjects/mp/checkout-page.js
+++ b/woocommerce/support/pageObjects/mp/checkout-page.js
@@ -4,8 +4,44 @@ export const MpCheckoutPage = {
     validateUrl(url) {
         cy.url().should('include', url);
     },
-    pay() {
-        cy.get(MpCheckoutElements.paymentMethods.pix.option).click();
+    selectPaymentMethod(paymentMethod) {
+        cy.get(MpCheckoutElements.paymentMethods[paymentMethod].option).click();
+    },
+    pay(){
         cy.get(MpCheckoutElements.finishButton).click();
+        cy.wait(5000);
+    },
+    fillCardData(cardFullName, site) {
+        const envs = Cypress.env(site);
+        cy.get(MpCheckoutElements.cardForm.holderName).type(cardFullName, {force: true});
+        cy.get(MpCheckoutElements.cardForm.cardNumber).type(envs.cards.master.number, {force: true});
+        cy.get(MpCheckoutElements.cardForm.expirationDate).type(envs.cards.master.expirationDate,{force: true});
+        cy.get(MpCheckoutElements.cardForm.cvv).type(envs.cards.master.cvv,{force: true});
+        
+    },
+    fillInputDocument(site){
+        const envs = Cypress.env(site);
+        cy.get(MpCheckoutElements.cardForm.document).type(envs.document.cpf,{force: true});
+    },
+    selectInstallments(){
+        cy.get(MpCheckoutElements.cardForm.installment).click();
+    },
+    nextPage() {
+        cy.get(MpCheckoutElements.nextButton).click();
+    }, 
+    continue(){
+        cy.get(MpCheckoutElements.continueButton).click();
+    },
+    fillEmailInput(site) {
+        const envs = Cypress.env(site);
+        cy.get(MpCheckoutElements.emailInput).type(envs.user.email);
+    },
+    fillPasswordInput(site) {
+        const envs = Cypress.env(site);
+        cy.get(MpCheckoutElements.passwordInput).type(envs.user.password);
+    },
+    doLogin(){
+        cy.get(MpCheckoutElements.loginButton).click();
+        cy.wait(2000);
     }
 }

--- a/woocommerce/support/pageObjects/mp/order-confirmation-page.js
+++ b/woocommerce/support/pageObjects/mp/order-confirmation-page.js
@@ -2,6 +2,6 @@ import {MpOrderConfirmationElements} from './../../elements/mp/order-confirmatio
 
 export const MpOrderConfirmationPage = {
     backToStore() {
-        cy.get(MpOrderConfirmationElements.backToStoreButton).click();
+        cy.get(MpOrderConfirmationElements.backToStoreButton).click({force: true});
     },
 }

--- a/woocommerce/support/pageObjects/store/order-page.js
+++ b/woocommerce/support/pageObjects/store/order-page.js
@@ -14,7 +14,7 @@ export const StoreOrderPage = {
                     cy.get(lastOrderLink).click();
                 });
             });
-        });
+        }).should('exist');
     },
 
     checkPaymentStatusBox(title) {

--- a/woocommerce/support/steps/checkout-pix-steps.js
+++ b/woocommerce/support/steps/checkout-pix-steps.js
@@ -23,7 +23,7 @@ And("que cliquei na opção de pagamento com o checkout Pix", () => {
     CheckoutPixPage.selectPaymentMethod();
 })
 
-And("cliquei em finalizar a compra", () => {
+When("cliquei em finalizar a compra", () => {
     CheckoutPage.finishCheckout();
 })
 
@@ -35,7 +35,7 @@ And("devo visualizar uma seção com o QR Code e o código do Pix", () => {
     CheckoutPixPage.getQRCode();
 })
 
-And("na página do pedido eu devo visualizar o status de pagamento pendente", () => {
+And("na página do pedido eu devo visualizar o status de pagamento pendente do pix", () => {
     StoreOrderPage.accessOrderPage();
     StoreLoginPage.doLoginIfNecessary();
     StoreOrderPage.accessLastOrder();

--- a/woocommerce/support/steps/checkout-pro-steps.js
+++ b/woocommerce/support/steps/checkout-pro-steps.js
@@ -7,6 +7,52 @@ import {MpCheckoutPage} from '../pageObjects/mp/checkout-page'
 import {MpOrderConfirmationPage} from '../pageObjects/mp/order-confirmation-page'
 import {StoreOrderConfirmationPage} from '../pageObjects/store/order-confirmation-page'
 
+
+//*Scenario: Realizando um pagamento com sucesso com um meio Off
+Given("que eu tenha um produto no carrinho", () => {
+    StorePage.accessStore();
+    StorePage.addFirstProductOnCart();
+})
+
+And("que eu esteja na página de checkout", () => {
+    StorePage.accessCart();
+    StorePage.accessCheckout();
+})
+
+And("preenchi corretamente os detalhes de faturamento", () => {
+    CheckoutPage.fillPersonalData('mlb');
+})
+
+And("que cliquei na opção de pagamento com o checkout PRO", () => {
+    CheckoutProPage.selectPaymentMethod();
+})
+
+When("cliquei em finalizar a compra", () => {
+    CheckoutPage.finishCheckout();
+})
+
+Then("devo ser redirecionado para o Mercado Pago", () => {
+    MpCheckoutPage.validateUrl('/checkout/v1/redirect');
+})
+
+And("deve concluir o fluxo de pagamento com Pix", () => {
+    MpCheckoutPage.selectPaymentMethod('pix');
+    MpCheckoutPage.pay();
+})
+
+And("ao concluir o fluxo de pagamento, deve ser redirecionado de volta a loja, na tela de pedido recebido", () => {
+    MpCheckoutPage.validateUrl('/congrats');
+    MpOrderConfirmationPage.backToStore();
+    StoreOrderConfirmationPage.validateUrl('/order-received');
+})
+
+And("na página do pedido eu devo visualizar o status de pagamento pendente", () => {
+    StoreOrderPage.accessOrderPage();
+    StoreLoginPage.doLoginIfNecessary();
+    StoreOrderPage.accessLastOrder();
+})
+
+//*Scenario: Realizando um pagamento com sucesso com cartão
 Given("que eu tenha um produto no carrinho", () => {
     StorePage.accessStore();
     StorePage.addFirstProductOnCart();
@@ -33,18 +79,104 @@ Then("devo ser redirecionado para o Mercado Pago", () => {
     MpCheckoutPage.validateUrl('/checkout/v1/redirect');
 })
 
-And("deve concluir o fluxo de pagamento", () => {
-    MpCheckoutPage.pay();
+And("deve concluir o fluxo de pagamento com cartão", () => {
+    MpCheckoutPage.selectPaymentMethod('creditCard');
+    MpCheckoutPage.fillCardData('APRO APRO', 'mlb');
+    MpCheckoutPage.nextPage();
+    MpCheckoutPage.fillInputDocument('mlb');
+    MpCheckoutPage.nextPage();
+    MpCheckoutPage.selectInstallments();
+    MpCheckoutPage.pay()
 })
 
-And("ao concluir o fluxo de pagamento, deve ser redirecionado de volta a loja, na tela de pedido recebido", () => {
+And("ao concluir o fluxo de pagamento, devo ver a tela de congrats", () => {
     MpCheckoutPage.validateUrl('/congrats');
-    MpOrderConfirmationPage.backToStore();
-    StoreOrderConfirmationPage.validateUrl('/order-received');
+    /* 
+    *The test can only go this far because cho pro card redirect causes an error: 
+    *https://github.com/cypress-io/cypress/issues/2367
+    */
 })
 
-And("na página do pedido eu devo visualizar o status de pagamento aprovado", () => {
-    StoreOrderPage.accessOrderPage();
-    StoreLoginPage.doLoginIfNecessary();
-    StoreOrderPage.accessLastOrder();
+//*Scenario: Realizando um pagamento com sucesso com cartão
+Given("que eu tenha um produto no carrinho", () => {
+    StorePage.accessStore();
+    StorePage.addFirstProductOnCart();
+})
+
+And("que eu esteja na página de checkout", () => {
+    StorePage.accessCart();
+    StorePage.accessCheckout();
+})
+
+And("preenchi corretamente os detalhes de faturamento", () => {
+    CheckoutPage.fillPersonalData('mlb');
+})
+
+And("que cliquei na opção de pagamento com o checkout PRO", () => {
+    CheckoutProPage.selectPaymentMethod();
+})
+
+And("cliquei em finalizar a compra", () => {
+    CheckoutPage.finishCheckout();
+})
+
+Then("devo ser redirecionado para o Mercado Pago", () => {
+    MpCheckoutPage.validateUrl('/checkout/v1/redirect');
+})
+
+And("deve falhar o fluxo de pagamento com cartão", () => {
+    MpCheckoutPage.selectPaymentMethod('creditCard');
+    MpCheckoutPage.fillCardData('OTHE OTHE', 'mlb');
+    MpCheckoutPage.nextPage();
+    MpCheckoutPage.fillInputDocument('mlb');
+    MpCheckoutPage.nextPage();
+    MpCheckoutPage.selectInstallments();
+    MpCheckoutPage.pay()
+})
+
+And("ao concluir o fluxo de pagamento, devo ver a tela de erro", () => {
+    MpCheckoutPage.validateUrl('/congrats/rejected');
+    /* 
+    *The test can only go this far because cho pro card redirect causes an error: 
+    *https://github.com/cypress-io/cypress/issues/2367
+    */
+})
+
+
+//*Scenario: Realizando um pagamento com sucesso com saldo em conta
+Given("que eu tenha um produto no carrinho", () => {
+    StorePage.accessStore();
+    StorePage.addFirstProductOnCart();
+})
+
+And("que eu esteja na página de checkout", () => {
+    StorePage.accessCart();
+    StorePage.accessCheckout();
+})
+
+And("preenchi corretamente os detalhes de faturamento", () => {
+    CheckoutPage.fillPersonalData('mlb');
+})
+
+And("que cliquei na opção de pagamento com o checkout PRO", () => {
+    CheckoutProPage.selectPaymentMethod();
+})
+
+When("cliquei em finalizar a compra", () => {
+    CheckoutPage.finishCheckout();
+})
+
+Then("devo ser redirecionado para o Mercado Pago", () => {
+    MpCheckoutPage.validateUrl('/checkout/v1/redirect');
+})
+
+And("deve concluir o fluxo de pagamento com saldo em conta", () => {
+    MpCheckoutPage.selectPaymentMethod('accountMoney');
+    //TODO: See how to handle with multi-tabs / multi-windows
+    //? is possible? https://docs.cypress.io/guides/references/trade-offs#Multiple-tabs
+    // MpCheckoutPage.fillEmailInput('mlb');
+    // MpCheckoutPage.nextPage();
+    // MpCheckoutPage.fillPasswordInput('mlb');
+    // MpCheckoutPage.doLogin();
+    // MpCheckoutPage.pay();
 })


### PR DESCRIPTION
### This Pull Request adds four test scenarios for CHO PRO

#### 1. Making a successful payment using an offline payment method

#### 2. Making a successful payment using an credit card payment method
>obs: the test can only go to the congrats screen because the redirect back to the store in Cypress causes an error like this: https://github.com/cypress-io/cypress/issues/2367

#### 3. Making a unsuccessful payment using an credit card payment method
>obs: the same observation in topic 2

#### 4. Making a successful payment with an account balance
>obs: In Cypress, the account balance option open another window containing the login form. The test can only go to the payment methods screen because handle with other windows cause a problem which is explained here: https://docs.cypress.io/guides/references/trade-offs#Multiple-tabs
the test was annotated with a TODO if there is a possibility of doing a workaround

![image](https://user-images.githubusercontent.com/84409541/160193251-a005e408-6809-46b0-80e3-c4e3c447b943.png)
